### PR TITLE
Tweak reporting guide

### DIFF
--- a/docs/OCP_CI_Tutorials/Reporting/Reporting_Guide.md
+++ b/docs/OCP_CI_Tutorials/Reporting/Reporting_Guide.md
@@ -40,9 +40,11 @@ As you may have read in other documents in this repository, you will need to app
 
 ### TestGrid Dashboard Creation and Modification Automation
 
-The automation we use to automatically create and modify dashboards in TestGrid can be found in the [openshift/ci-tools](https://github.com/openshift/ci-tools) repository. We utilize the [`testgrid-config-generator`](https://github.com/openshift/ci-tools/tree/master/cmd/testgrid-config-generator) tool in that repository to find any Prow jobs that contain either `-lp-interop-` or `-lp-interop` in their names. If a new Prow job is found that isn't being reported, the tool will create a new dashboard or modify an existing dashboard to report that job to TestGrid appropriately. After the tool has run, it will create a pull request in the [kubernetes/test-infra](https://github.com/kubernetes/test-infra) repository to finalize the changes.
+The automation we use to automatically create and modify dashboards in TestGrid can be found in the [openshift/ci-tools](https://github.com/openshift/ci-tools) repository. We utilize the [testgrid-config-generator] tool in that repository to find any Prow jobs that contain either `-lp-interop` in their names. If a new Prow job is found that isn't being reported, the tool will create a new dashboard or modify an existing dashboard to report that job to TestGrid appropriately. After the tool has run, it will create a pull request in the [kubernetes/test-infra][kubernetes-test-infra] repository to finalize the changes.
 
-The [`testgrid-config-generator`](https://github.com/openshift/ci-tools/tree/master/cmd/testgrid-config-generator) tool is run daily and you should not need to force it to run. After the tools runs, it may take some time for the pull request to be merged into the [kubernetes/test-infra](https://github.com/kubernetes/test-infra) repository. Once the pull request is merged, it will start to show in TestGrid.
+The [testgrid-config-generator] tool is run daily and you should not need to force it to run. After the tools runs, it may take some time for the pull request to be merged into the [kubernetes/test-infra] repository. Once the pull request is merged, it will start to show in TestGrid.
+
+To add support for automatically detecting layered product interoperability jobs, a [PR](https://github.com/openshift/ci-tools/pull/3289) was opened to [testgrid-config-generator] support these unique identifier.
 
 > **NOTE:**
 >
@@ -55,3 +57,6 @@ TBD
 ## Slack
 
 TBD
+
+[testgrid-config-generator]: https://github.com/openshift/ci-tools/tree/master/cmd/testgrid-config-generator
+[kubernetes-test-infra]: https://github.com/kubernetes/test-infra


### PR DESCRIPTION
Includes:
 * Only state one unique identifier that can be included in prow jobs to be automatically picked up by testgrid-config-generator
 * Add contect for how testgrid-config-generator was able to pick up layered product interoperabiltiy jobs
 * Added relative links for duplicated links throughout the file