### PR TITLE
Remove second link to Scenario Development Guide as it breaks GitBook…

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -13,7 +13,6 @@
 
 ## Tutorials
 
-- [Scenario Development](OCP_CI_Tutorials/Scenario_Development/Scenario_Development_Guide.md)
 - [Containers](OCP_CI_Tutorials/Containers/Container_Creation_Guide.md)
 - [Secrets](OCP_CI_Tutorials/Secrets/Secrets_Guide.md)
 - [Step Registry](OCP_CI_Tutorials/Step_Registry/Step_Registry_Guide.md)


### PR DESCRIPTION
For whatever reason, the second link to the Scenario Development Guide doesn't work. This seems to be an issue in GitBook. Removing the link for now.