### PR TITLE
[INTEROP-7895] Updating Mapping Files

### DIFF
--- a/docs/OCP_CI_Tutorials/Scenario_Development/Scenario_Development_Guide.md
+++ b/docs/OCP_CI_Tutorials/Scenario_Development/Scenario_Development_Guide.md
@@ -355,7 +355,7 @@ There might be a case when we need to use the existing quay image in our scenari
 
 #### How to Mirror Public Image
 
-If the image is public, we can mirror the image by adding a mapping in file `core-services/image-mirroring/supplemental-ci-images/mapping_supplemental_ci_images_ci` of [openshift/release](https://github.com/openshift/release/blob/master/core-services/image-mirroring/supplemental-ci-images/mapping_supplemental_ci_images_ci) repository. The format of adding image mapping is:
+If the image is public, we can mirror the image by adding a mapping in file `core-services/image-mirroring/_config.yaml` of [openshift/release](https://github.com/openshift/release/blob/master/core-services/image-mirroring/_config.yaml) repository. The format of adding image mapping is:
 
 ```yaml
 quay.io/QUAY_REPOSITORY/test-image:latest registry.ci.openshift.org/ci/test-image:latest


### PR DESCRIPTION
Related JIRA : [[INTEROP-7895](https://issues.redhat.com/browse/INTEROP-7895)] 

Updating Mirroring the Public Quay Image Document ->
https://cspi.gitbook.io/ocp-ci-onboarding/onboarding/onboarding_guide/scenario_development_guide#how-to-mirror-public-image
The mapping files are replaced with the mapping in the configuration file in the core-services/image-mirroring/_config.yaml. https://docs.ci.openshift.org/docs/how-tos/external-images/

The path changes from `core-services/image-mirroring/supplemental-ci-images/mapping_supplemental_ci_images_ci` to `core-services/image-mirroring/_config.yaml` within [openshift/release](https://github.com/openshift/release/blob/master/core-services/image-mirroring/_config.yaml) repository.