### PR TITLE
Add docs for our automations and workflows

### DIFF
--- a/docs/OCP_CI_Tutorials/Reporting/Reporting_Guide.md
+++ b/docs/OCP_CI_Tutorials/Reporting/Reporting_Guide.md
@@ -21,6 +21,7 @@
   - [Sippy](#sippy)
   - [CI Test Mapping](#ci-test-mapping)
   - [Verification](#verification)
+- [Report Portal Upload (Data Router)](#report-portal-upload-data-router)
 
 ## TestGrid
 
@@ -165,6 +166,14 @@ flowchart TD
    - `FIREWATCH_JIRA_SERVER`: `https://issues.redhat.com`
      - This value always defaults to the stage server to avoid unwanted bugs.
    - `FIREWATCH_DEFAULT_JIRA_ADDITIONAL_LABELS` : Adding the following 3 labels to every firewatch config step: `["<ocp-version>-lp","self-managed-lp","<scenario-short-name-lp>"]`
+
+**If you are onboarding to Component Readiness on AWS IPI:**
+
+1. Use the [`firewatch-ipi-aws-cr`](https://steps.ci.openshift.org/workflow/firewatch-ipi-aws-cr) workflow instead of `firewatch-ipi-aws` or `ipi-aws`. Official
+   documentation: [`firewatch-ipi-aws-cr`](https://steps.ci.openshift.org/workflow/firewatch-ipi-aws-cr).
+2. Add the Firewatch environment variables listed above for `firewatch-ipi-aws`.
+3. Set `DR__RP__CR_COMP_NAME` and `MAP_TESTS` as described in [Report Portal Upload (Data Router)](#report-portal-upload-data-router) and
+   [Ensuring JUnit XML TS Names Have Correct Prefix](#ensuring-junit-xml-ts-names-have-correct-prefix).
 
 **If you currently use a custom workflow:**
 
@@ -372,10 +381,10 @@ The following changes are required:
       [`testSuitePatterns`](https://github.com/openshift/sippy/blob/main/pkg/db/suites.go) RegEx pattern and the
       [`includeSuitePatterns`](https://github.com/openshift-eng/ci-test-mapping/blob/main/config/openshift-eng.yaml) SQL `LIKE` pattern.
     - `DR__RP__CR_COMP_NAME` must be set in this file whenever the Job executes the
-      [`mpiit-data-router-reporter`](https://github.com/openshift/release/blob/main/ci-operator/step-registry/mpiit/data-router-reporter/mpiit-data-router-reporter-commands.sh)
-      CI Operator Step (directly, or indirectly via a CI Operator Chain or CI Operator Workflow, such as
-      [`firewatch-ipi-aws-cr`](https://steps.ci.openshift.org/workflow/firewatch-ipi-aws-cr)), or the Job incorporates a Single-Stage Test (via
-      [`literal_step`](https://steps.ci.openshift.org/ci-operator-reference) stanza) performing an equivalent action.
+      [`mpiit-data-router-reporter`](https://steps.ci.openshift.org/reference/mpiit-data-router-reporter) CI Operator Step (directly, or indirectly via a CI
+      Operator Chain or CI Operator Workflow, such as [`firewatch-ipi-aws-cr`](https://steps.ci.openshift.org/workflow/firewatch-ipi-aws-cr)), or the Job
+      incorporates a Single-Stage Test (via [`literal_step`](https://steps.ci.openshift.org/ci-operator-reference) stanza) performing an equivalent action.
+      See [Report Portal Upload (Data Router)](#report-portal-upload-data-router) for details.
  2. In the CI Operator Step Script that performs the test and produces the JUnit XML result files (the post-processing helper is provided by
     [RedHatQE/OpenShift-LP-QE--Tools](https://github.com/RedHatQE/OpenShift-LP-QE--Tools)):
 
@@ -828,4 +837,31 @@ Commit all changes in a single PR against the `main` branch of [openshift-eng/ci
 After all three PRs are merged, navigate to the CR LP OCP Compat View for the target OCP release (for example,
 [4.22-LP-OCP-Compat--lpGA](https://sippy.dptools.openshift.org/sippy-ng/component_readiness/main?view=4.22-LP-OCP-Compat--lpGA)) and confirm the product label
 appears in the results. If the product does not appear, contact TRT at `#forum-ocp-release-oversight` on Slack.
+
+## Report Portal Upload (Data Router)
+
+Official documentation:
+
+- [Report Portal](https://reportportal.io/docs/)
+- [Data Router](https://datarouter.dno.corp.redhat.com/docs) (VPN required)
+- [`mpiit-data-router-reporter`](https://steps.ci.openshift.org/reference/mpiit-data-router-reporter) — CI Operator Step maintained by CSPI-QE
+- [`firewatch-ipi-aws-cr`](https://steps.ci.openshift.org/workflow/firewatch-ipi-aws-cr) — CI Operator Workflow that includes the step above
+
+For LP OCP Compat jobs onboarded to Component Readiness, JUnit XML result files produced during the test must be published to Report Portal so that CR can
+consume them. The CSPI-QE team maintains the [`mpiit-data-router-reporter`](https://steps.ci.openshift.org/reference/mpiit-data-router-reporter) CI Operator
+Step for this purpose.
+
+Key behavior:
+
+- **`REPORTPORTAL_APPLY_TFA`** (default: `true`) — instructs Report Portal to perform Test Failure Analysis (TFA) on uploaded results.
+- **`DR__RP__CR_COMP_NAME`** — sets the Report Portal launch name and the `ComponentReadiness_ComponentName` launch attribute. Must match the JUnit
+  `<testsuite name="...">` prefix (see [Ensuring JUnit XML TS Names Have Correct Prefix](#ensuring-junit-xml-ts-names-have-correct-prefix)).
+- **`OCP_VERSION`**, **`FIPS_ENABLED`**, **`JOB_NAME`**, and **`BUILD_ID`** — included as launch metadata attributes automatically.
+
+The easiest way to include this step in an AWS IPI job is to use the [`firewatch-ipi-aws-cr`](https://steps.ci.openshift.org/workflow/firewatch-ipi-aws-cr)
+workflow, which runs `mpiit-data-router-reporter` after cluster deprovisioning and before
+[`firewatch-report-issues`](https://steps.ci.openshift.org/reference/firewatch-report-issues).
+
+For custom workflows, add the [`mpiit-data-router-reporter`](https://steps.ci.openshift.org/reference/mpiit-data-router-reporter) ref to the post steps
+directly.
 

--- a/docs/OCP_CI_Tutorials/Scenario_Development/Scenario_Development_Guide.md
+++ b/docs/OCP_CI_Tutorials/Scenario_Development/Scenario_Development_Guide.md
@@ -255,6 +255,22 @@ We add AWS user tags to name aws resources by scenario, set the USER_TAGS env va
         scenario mtr
 ```
 
+### `firewatch-ipi-aws-cr`<!-- omit from toc -->
+
+Official documentation: [`firewatch-ipi-aws-cr`](https://steps.ci.openshift.org/workflow/firewatch-ipi-aws-cr)
+
+This workflow extends [`firewatch-ipi-aws`](#firewatch-ipi-aws) for Layered Product OCP Compatibility (LP OCP Compat) scenarios that onboard to
+[Component Readiness](../Reporting/Reporting_Guide.md#component-readiness). It provides the same AWS IPI cluster provisioning, deprovisioning, and Jira failure
+reporting as `firewatch-ipi-aws`, and adds a post step that uploads JUnit XML result files from the CI Operator Job run to
+[Report Portal](https://redhat.atlassian.net/wiki/display/CentralCI/D%26O+Data+Router) via the
+[`mpiit-data-router-reporter`](https://steps.ci.openshift.org/reference/mpiit-data-router-reporter) ref, with Test Failure Analysis (TFA) applied by default.
+
+Use `firewatch-ipi-aws` for standard LP interop scenarios; use `firewatch-ipi-aws-cr`
+when onboarding to Component Readiness on AWS IPI.
+
+Set `DR__RP__CR_COMP_NAME` in the job environment. See
+[Report Portal Upload (Data Router)](../Reporting/Reporting_Guide.md#report-portal-upload-data-router) in the Reporting Guide.
+
 ### `firewatch-rosa-aws-sts` & `firewatch-rosa-aws-sts-hypershift` <!-- omit from toc -->
 
 step-registry doc (ROSA Classic): [firewatch-rosa-aws-sts](https://steps.ci.openshift.org/workflow/firewatch-rosa-aws-sts)

--- a/docs/OCP_CI_Tutorials/Step_Registry/Step_Registry_Guide.md
+++ b/docs/OCP_CI_Tutorials/Step_Registry/Step_Registry_Guide.md
@@ -9,6 +9,7 @@
   - [Workflows](#workflows)
 - [The interop Folder](#the-interop-folder)
   - [Tooling](#tooling)
+  - [CSPI-Maintained Steps Outside `interop/tooling`](#cspi-maintained-steps-outside-interoptooling)
   - [Scenarios](#scenarios)
 
 ## Introduction
@@ -53,6 +54,20 @@ The `ci-operator/step-registry/interop` folder is meant to house all of our scen
 ### Tooling
 
 The `ci-operator/step-registry/interop/tooling` folder is meant to hold any re-usable tooling the CSPI team created in the OpenShift CI step registry. These tools are encouraged to be used both in CSPI interop testing and in tests that other teams may be working on. We will own and maintain these tools.
+
+### CSPI-Maintained Steps Outside `interop/tooling`
+
+The CSPI-QE team also maintains re-usable steps elsewhere in the step registry. These are owned by `cspi-qe-ocp-lp` and documented on
+[steps.ci.openshift.org](https://steps.ci.openshift.org/):
+
+| Step | Type | Purpose | Official documentation |
+|------|------|---------|------------------------|
+| `firewatch-ipi-aws-cr` | Workflow | AWS IPI provisioning with Report Portal upload and Jira failure reporting for LP OCP Compat / CR jobs | [`firewatch-ipi-aws-cr`](https://steps.ci.openshift.org/workflow/firewatch-ipi-aws-cr) |
+| `mpiit-data-router-reporter` | Ref | Uploads JUnit XML result files from a CI Operator Job run to Report Portal via Data Router, with TFA applied by default | [`mpiit-data-router-reporter`](https://steps.ci.openshift.org/reference/mpiit-data-router-reporter) |
+| `firewatch-report-issues` | Ref | Reports CI Operator Job failures to Jira using Firewatch rules | [`firewatch-report-issues`](https://steps.ci.openshift.org/reference/firewatch-report-issues) |
+
+For usage guidance, see the [`firewatch-ipi-aws-cr` workflow section](../Scenario_Development/Scenario_Development_Guide.md#firewatch-ipi-aws-cr) in the Scenario
+Development Guide and [Report Portal Upload (Data Router)](../Reporting/Reporting_Guide.md#report-portal-upload-data-router) in the Reporting Guide.
 
 ### Scenarios
 


### PR DESCRIPTION
## Summary

Document CSPI-QE-maintained OpenShift CI step registry assets used for LP OCP Compat / Component Readiness onboarding:

- Add **`firewatch-ipi-aws-cr`** to the Scenario Development Guide under Important Workflows, describing when to use it vs. `firewatch-ipi-aws` and how it uploads JUnit results to Report Portal with TFA via `mpiit-data-router-reporter`.
- Add a new top-level **Report Portal Upload (Data Router)** section to the Reporting Guide, with links to [Report Portal](https://reportportal.io/docs/), [Data Router](https://datarouter.dno.corp.redhat.com/docs) (VPN required), and the official step registry pages for [`mpiit-data-router-reporter`](https://steps.ci.openshift.org/reference/mpiit-data-router-reporter) and [`firewatch-ipi-aws-cr`](https://steps.ci.openshift.org/workflow/firewatch-ipi-aws-cr).
- Extend **How To Add Jira Reporting to a Scenario** with guidance for CR onboarding on AWS IPI using `firewatch-ipi-aws-cr`.
- Add a **CSPI-Maintained Steps Outside `interop/tooling`** catalog to the Step Registry Guide listing `firewatch-ipi-aws-cr`, `mpiit-data-router-reporter`, and `firewatch-report-issues`.
- Update Component Readiness cross-references to use `steps.ci.openshift.org` as the canonical documentation for the data router reporter step.